### PR TITLE
Add Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: nix
+env:
+  - NIXPKGS_CHANNEL=17.03
+  - NIXPKGS_CHANNEL=unstable
+script: nix-build -I "nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-$NIXPKGS_CHANNEL.tar.gz" -A yarn2nix

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # yarn2nix
+<img src="https://travis-ci.org/moretea/yarn2nix.svg?branch=master">
 
 Converts `yarn.lock` files into nix expression.
 


### PR DESCRIPTION
I found out that `yarn2nix` builds fine on the current stable version (17.03), but does not build on unstable. This is the issue reported in https://github.com/moretea/yarn2nix/issues/27.

Travis builds: https://travis-ci.org/moretea/yarn2nix/builds/231509275

To prevent future breakage when we merge something, I've added this minimal travis test that will just attempt to package yarn2nix with itself.

Although I really would like to add some tests (see https://github.com/moretea/yarn2nix/issues/26), this will ready help a bit.