### PR TITLE
Fix permission error #27 in 17.09pre

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -54,6 +54,7 @@ rec {
 
         cp ${packageJson} ./package.json
         cp ${yarnLock} ./yarn.lock
+        chmod +w ./yarn.lock
 
         yarn config --offline set yarn-offline-mirror ${offlineCache}
 


### PR DESCRIPTION
Apparently in 17.09pre, the `yarn.lock` file is read only, whilst yarn attempts to open it in RW mode.