### PR TITLE
fix the offline-cache name heuristic

### DIFF
--- a/bin/yarn2nix.js
+++ b/bin/yarn2nix.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 "use strict";
 
+const path = require("path");
+
 const HEAD = `
 {fetchurl, linkFarm}: rec {
   offline_cache = linkFarm "offline" packages;
@@ -16,11 +18,8 @@ function generateNix(lockedDependencies) {
     let dep = lockedDependencies[depRange];
 
     let depRangeParts = depRange.split('@');
-    let name = depRangeParts[depRangeParts[0]!=""?0:1];
-    let nameParts = name.split('/')
-    name = nameParts[nameParts.length-1];
-    let version = dep["version"];
-    let file_name = name + "-" + version + ".tgz";
+    let [url, sha1] = dep["resolved"].split("#");
+    let file_name = path.basename(url)
 
     if (found.hasOwnProperty(file_name)) {
       console.error("HUH! Found " + file_name + " more than once!");
@@ -30,7 +29,6 @@ function generateNix(lockedDependencies) {
       found[file_name] = null;
     }
 
-    let [url, sha1] = dep["resolved"].split("#");
 
     console.log(`
     {


### PR DESCRIPTION
yarn actually looks for the basename of the URL instead of the package
name in the offline cache. Most of the time it works because it's the
same but it's not always the case. For example the following:

```
 brace@ooblahman/brace:
   version "0.7.0"
   resolved "https://codeload.github.com/ooblahman/brace/tar.gz/9258ccc4d83e6bdec7edd9a91412e16e84aef983#704e6a63675b08786fdfa83c3e813cc6c3d08b5a"
   dependencies:
     w3c-blob "0.0.1"
```

(disregard the fact that that url has a hash, yarn doesn't add hashes to github archives)