### PR TITLE
Don't forget to copy node_modules/.bin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -119,6 +119,7 @@ rec {
 
         mkdir -p $out/node_modules
         ln -s ${deps}/node_modules/* $out/node_modules/
+        ln -s ${deps}/node_modules/.bin $out/node_modules/
 
         if [ -d $out/node_modules/${npmPackageName} ]; then
           echo "Error! There is already an ${npmPackageName} package in the top level node_modules dir!"


### PR DESCRIPTION
`package.json` scripts usually depend on binaries under `node_modules/.bin`. `*` didn't capture `.bin` so I explicitly created a link for it as well.