### PR TITLE
refactor default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -111,21 +111,21 @@ rec {
       configurePhase = attrs.configurePhase or ''
         runHook preConfigure
 
-        if [ -d node_modules ]; then
-          echo "Node modules dir present. Removing."
-          rm -rf node_modules
-        fi
-
         if [ -d npm-packages-offline-cache ]; then
           echo "npm-pacakges-offline-cache dir present. Removing."
           rm -rf npm-packages-offline-cache
         fi
 
-        mkdir -p $out/node_modules
-        ln -s ${deps}/node_modules/* $out/node_modules/
-        ln -s ${deps}/node_modules/.bin $out/node_modules/
+        if [ -d node_modules ]; then
+          echo "Node modules dir present. Removing."
+          rm -rf node_modules
+        fi
 
-        if [ -d $out/node_modules/${pname} ]; then
+        mkdir -p node_modules
+        ln -s ${deps}/node_modules/* node_modules/
+        ln -s ${deps}/node_modules/.bin node_modules/
+
+        if [ -d node_modules/${pname} ]; then
           echo "Error! There is already an ${pname} package in the top level node_modules dir!"
           exit 1
         fi
@@ -138,8 +138,10 @@ rec {
       installPhase = attrs.installPhase or ''
         runHook preInstall
 
-        mkdir $out/node_modules/${pname}/
-        cp -r * $out/node_modules/${pname}/
+        mkdir -p $out
+        cp -r node_modules $out/node_modules
+        cp -r . $out/node_modules/${pname}
+        rm -rf $out/node_modules/${pname}/node_modules
 
         mkdir $out/bin
         node ${./nix/fixup_bin.js} $out ${lib.concatStringsSep " " publishBinsFor_}


### PR DESCRIPTION
This breaks backward-compatibility completely.

Renames for consistency:
* generateYarnNix -> mkYarnNix
* loadOfflineCache -> importOfflineCache
* buildYarnPackage -> mkYarnPackage
* buildYarnPackageDeps -> mkYarnModules

mkYarnPackage has been overhauled to be more flexible and support
various scenarios. Default options are also provided for more attributes
to minimize the boilerplate for package writers.

Here is a frontend package example:

    mkYarnPackage {
      src = ./.;
      # package.json and yarn.lock paths are inferred from src
      # name is inferred from package.json

      buildPhase = ''
        # generates the dist/ folder from the source
        yarn build
      '';

      # this replaces the default phase that links the .bin folder
      installPhase = ''
        cp -r dist/ $out
      '';
    }

As far as I know this supports all the use-case scenarios that I am
aware of.