### PR TITLE
re-expose yarn

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@
 
 pkgs.lib.fix (self: rec {
   inherit (pkgs) stdenv lib fetchurl linkFarm;
+  inherit yarn;
 
   unlessNull = item: alt:
     if item == null then alt else item;


### PR DESCRIPTION
This makes it easier to find out which yarn was passed to yarn2nix and
fixes the README.md installation instructions.

Fixes #43