### PR TITLE
Add support for local and GitHub packages

### DIFF
--- a/bin/yarn2nix.js
+++ b/bin/yarn2nix.js
@@ -2,45 +2,96 @@
 "use strict";
 
 const path = require("path");
+const cp = require("child_process");
 
-const HEAD = `
-{fetchurl, linkFarm}: rec {
-  offline_cache = linkFarm "offline" packages;
-  packages = [
-`.trim();
+const remoteToString = function(remote) {
+  return `
+    {
+      name = "${remote.file_name}";
+      path = fetchurl {
+        name = "${remote.file_name}";
+        url  = "${remote.url}";
+        sha1 = "${remote.sha1}";
+      };
+    }`;
+}
 
-function generateNix(lockedDependencies) {
+const localToString = function(local) {
+  return `
+    {
+      name = "${local.file_name}";
+      path = ${local.file_name};
+    }`;
+}
+
+const arrayToString = function(elements) {
+  return `[
+    ${elements.join("\n")}
+  ]`;
+}
+
+const astToString = function(ast) {
+  const remotes = ast.links
+    .filter(function(link) { return link.hasOwnProperty('remote'); })
+    .map(function(link) { return remoteToString(link.remote); });
+
+  const locals = ast.links
+    .filter(function(link) { return link.hasOwnProperty('local'); })
+    .map(function(link) { return localToString(link.local); });
+
+  return `
+  {fetchurl, linkFarm}: rec {
+    offline_cache = linkFarm "offline" packages;
+    packages = ${arrayToString(remotes)};
+    localPackages = ${arrayToString(locals)};
+  }`;
+};
+
+function yarnToAst(lockedDependencies) {
   let found = {};
 
-  console.log(HEAD)
+  return {
+    links: Object.keys(lockedDependencies).map(function(depRange) {
+      let dep = lockedDependencies[depRange];
 
-  for (var depRange in lockedDependencies) {
-    let dep = lockedDependencies[depRange];
+      let depRangeParts = depRange.split('@');
+      if ('resolved' in dep) {
+        let url;
+        let sha1;
+        let file_name;
+        if (/codeload.github.com.*tar.gz\//.test(dep["resolved"])) {
+          url = dep["resolved"];
+          sha1 = cp.execSync("curl -sS " + url + " | shasum | cut -d \" \" -f 1").toString().trim();
+          var matches = /tar.gz\/(.*)/.exec(url);
+          file_name = matches[1];
+        } else {
+          url = dep["resolved"].split("#")[0];
+          sha1 = dep["resolved"].split("#")[1];
+          file_name = path.basename(url);
+        }
 
-    let depRangeParts = depRange.split('@');
-    let [url, sha1] = dep["resolved"].split("#");
-    let file_name = path.basename(url)
+        if (found.hasOwnProperty(file_name)) {
+          return {};
+        } else {
+          found[file_name] = null;
+        }
 
-    if (found.hasOwnProperty(file_name)) {
-      continue;
-    } else {
-      found[file_name] = null;
-    }
-
-
-    console.log(`
-    {
-      name = "${file_name}";
-      path = fetchurl {
-        name = "${file_name}";
-        url  = "${url}";
-        sha1 = "${sha1}";
-      };
-    }`)
-  }
-
-  console.log("  ];")
-  console.log("}")
+        return {
+          remote: {
+            file_name: file_name,
+            url: url,
+            sha1: sha1
+          }
+        };
+      } else {
+        return {
+          local: {
+            file_name: depRange.split("@")[1]
+          }
+        };
+      }
+    })
+  };
 }
 
 const yarnLock = process.argv[2] || "yarn.lock";
@@ -54,4 +105,4 @@ if (json.type != "success") {
   throw new Error("yarn.lock parse error")
 }
 
-generateNix(json.object);
+console.log(astToString(yarnToAst(json.object)));

--- a/default.nix
+++ b/default.nix
@@ -40,6 +40,8 @@ pkgs.lib.fix (self: rec {
   }:
     let
       offlineCache = importOfflineCache yarnNix;
+      locals = (import yarnNix { inherit fetchurl linkFarm; }).localPackages or [];
+      copyCommands = lib.concatMapStrings (l: "mkdir -p \$(dirname ${l.name}); cp -R ${l.path} ${l.name};") locals;
       extraBuildInputs = (lib.flatten (builtins.map (key:
         pkgConfig.${key} . buildInputs or []
       ) (builtins.attrNames pkgConfig)));
@@ -68,6 +70,13 @@ pkgs.lib.fix (self: rec {
         chmod +w ./yarn.lock
 
         yarn config --offline set yarn-offline-mirror ${offlineCache}
+        yarn config --offline set yarn-offline-mirror-pruning false
+        yarn config set yarn-offline-mirror-pruning false
+
+        ls -l
+        /usr/local/bin/tree -l ${offlineCache}
+
+        ${copyCommands}
 
         # Do not look up in the registry, but in the offline cache.
         # TODO: Ask upstream to fix this mess.


### PR DESCRIPTION
I needed support local and GitHub packages, which look like this in `package.json`:

```
  "foo": "./lib/foo",
  "bar-repo": "github:user/bar-repo"
```

This was hacked together pretty quickly as a proof of concept. Ultimately I can't use yarn2nix because some of my dependencies attempt to install packages at runtime (e.g. protobuf via the `pbjs` command) and that fails because `node_modules` is symlinked into `/nix/store` somewhere, which is read-only.

I figured I would put up this PR in case someone wants this functionality and is willing to fix it up a bit.