### PR TITLE
Remove fixed point & don't export unnecessary symbols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: nix
 env:
-  - NIXPKGS_CHANNEL=17.03
+  - NIXPKGS_CHANNEL=17.09
   - NIXPKGS_CHANNEL=unstable
 
 # By building the tests, we also build yarn2nix itself.

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ env:
   - NIXPKGS_CHANNEL=unstable
 
 # By building the tests, we also build yarn2nix itself.
-script: nix-build -I "nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-$NIXPKGS_CHANNEL.tar.gz" -A tests
+script: nix-build -I "nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-$NIXPKGS_CHANNEL.tar.gz" tests.nix

--- a/default.nix
+++ b/default.nix
@@ -3,9 +3,10 @@
 , yarn ? pkgs.yarn
 }:
 
-pkgs.lib.fix (self: rec {
+let
   inherit (pkgs) stdenv lib fetchurl linkFarm;
   inherit yarn;
+in rec {
 
   unlessNull = item: alt:
     if item == null then alt else item;
@@ -181,6 +182,4 @@ pkgs.lib.fix (self: rec {
     # All the other projects can auto-generate that file.
     yarnNix = ./yarn.nix;
   };
-
-  tests = import ./tests { yarn2nix = self; };
-})
+}

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,9 @@
 
 let
   inherit (pkgs) stdenv lib fetchurl linkFarm;
-  inherit yarn;
 in rec {
+  # Export yarn again to make it easier to find out which yarn was used.
+  inherit yarn;
 
   unlessNull = item: alt:
     if item == null then alt else item;

--- a/tests.nix
+++ b/tests.nix
@@ -1,0 +1,1 @@
+import ./tests { yarn2nix = import ./default.nix {}; }


### PR DESCRIPTION
I introduced a fixed point to to be able to call the tests from `default.nix`.
Based on all the things I've heard at NixCon 2017, it's not worth the trouble compared to having a separate `tests.nix` file.
    
Also, I've prevented the `stdenv`, `lib`, `fetchurl`, `linkFarm` and `yarn` keys from leaking into the returned attribute set.