### PR TITLE
Automatic Yarn Workspace import 

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -8,15 +8,7 @@ let
   };
 in
 (listToAttrs (build ["wetty" "weave-front-end" "sendgrid-helpers"])) // {
-  workspace = rec {
-    package-one = yarn2nix.mkYarnPackage {
-      src = ./workspace/package-one;
-      yarnLock = ./workspace/yarn.lock;
-      workspaceDependencies = { inherit package-two; };
-    };
-    package-two = yarn2nix.mkYarnPackage {
-      src = ./workspace/package-two;
-      yarnLock = ./workspace/yarn.lock;
-    };
-  }.package-one;
+  workspace = (yarn2nix.mkYarnWorkspace {
+    src = ./workspace;
+  }).package-one;
 }

--- a/tests/workspace/package.json
+++ b/tests/workspace/package.json
@@ -1,4 +1,4 @@
 {
     "private": true,
-    "workspaces": ["package-one", "package-two"]
+    "workspaces": ["package-*"]
 }


### PR DESCRIPTION
See #57 for the initial ticket. #58 adds the basic plumbing, but requires you to manually define the workspace. This will automatically import the "master" `package.json` and find all subpackages.

This is a bit more complicated than it has any right to be. Most of this is because it tries to implement Yarn's (and most shells') globbing behaviour. Maybe that should be moved to Nixpkgs' lib eventually, since it doesn't really have anything to do with Yarn in particular...