### PR TITLE
Scoped packages fixes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -243,14 +243,8 @@ in
           rm -rf node_modules
         fi
 
-        mkdir -p node_modules
-        # ln gets confused when the glob doesn't match anything
-        if [ "$(ls $node_modules | wc -l)" -gt 0 ]; then
-          ln -s $node_modules/* node_modules/
-        fi
-        if [ -d $node_modules/.bin ]; then
-          ln -s $node_modules/.bin node_modules/
-        fi
+        cp -r $node_modules node_modules
+        chmod -R +w node_modules
 
         ${workspaceDependencyCopy}
 
@@ -268,8 +262,7 @@ in
         runHook preInstall
 
         mkdir -p $out
-        cp -rL node_modules $out/node_modules
-        chmod -R +w $out/node_modules
+        mv node_modules $out/node_modules
         mkdir -p $out/node_modules/${pname}
         cp -r . $out/node_modules/${pname}
         rm -rf $out/node_modules/${pname}/node_modules

--- a/default.nix
+++ b/default.nix
@@ -247,6 +247,8 @@ in
         # ln gets confused when the glob doesn't match anything
         if [ "$(ls $node_modules | wc -l)" -gt 0 ]; then
           ln -s $node_modules/* node_modules/
+        fi
+        if [ -d $node_modules/.bin ]; then
           ln -s $node_modules/.bin node_modules/
         fi
 
@@ -266,7 +268,8 @@ in
         runHook preInstall
 
         mkdir -p $out
-        cp -r node_modules $out/node_modules
+        cp -rL node_modules $out/node_modules
+        chmod -R +w $out/node_modules
         mkdir -p $out/node_modules/${pname}
         cp -r . $out/node_modules/${pname}
         rm -rf $out/node_modules/${pname}/node_modules

--- a/default.nix
+++ b/default.nix
@@ -207,7 +207,7 @@ in
         name = "${safeName}-modules-${version}";
         preBuild = yarnPreBuild;
         workspaceDependencies = workspaceDependenciesTransitive;
-        inherit packageJSON version yarnLock yarnNix yarnFlags pkgConfig;
+        inherit packageJSON pname version yarnLock yarnNix yarnFlags pkgConfig;
       };
       publishBinsFor_ = unlessNull publishBinsFor [pname];
       workspaceDependenciesTransitive = uniqueByPackageName

--- a/default.nix
+++ b/default.nix
@@ -216,7 +216,10 @@ in
         lib.concatStringsSep
           "\n"
           (builtins.map
-            (dep: "cp -r --no-preserve=all ${dep.src} node_modules/${dep.pname}")
+            (dep: ''
+              mkdir -p node_modules/${dep.pname}
+              cp -r --no-preserve=all ${dep.src} node_modules/${dep.pname}
+            '')
             workspaceDependenciesTransitive);
     in stdenv.mkDerivation (builtins.removeAttrs attrs ["pkgConfig" "workspaceDependencies"] // {
       inherit src;
@@ -264,6 +267,7 @@ in
 
         mkdir -p $out
         cp -r node_modules $out/node_modules
+        mkdir -p $out/node_modules/${pname}
         cp -r . $out/node_modules/${pname}
         rm -rf $out/node_modules/${pname}/node_modules
 


### PR DESCRIPTION
Package names like `@foo/bar` cannot be used for derivation or file names, but should be used to create paths inside of derivations.