### PR TITLE
yarnNix derivations fail when yarn2nix.js does

### DIFF
--- a/bin/yarn2nix.js
+++ b/bin/yarn2nix.js
@@ -141,4 +141,7 @@ Promise.all(pkgs.map(updateResolvedSha1)).then(() => {
   if (!options['--no-nix']) {
     generateNix(json.object);
   }
-})
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
This is just a matter of easier debugging.  Currently if anything causes yarn2nix.js to crash, it will "successfully" write an incomplete nix file to the nix store, causing errors on import.