### PR TITLE
Support cyclic workspace dependencies

### DIFF
--- a/tests.nix
+++ b/tests.nix
@@ -1,1 +1,1 @@
-import ./tests { yarn2nix = import ./default.nix {}; }
+import ./tests { yarn2nix = import ./default.nix {}; inherit (import <nixpkgs> {}) fetchFromGitHub; }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,4 +1,4 @@
-{ yarn2nix }:
+{ yarn2nix, fetchFromGitHub }:
 with builtins;
 let
   build = names: map buildEntry names;
@@ -11,4 +11,18 @@ in
   workspace = (yarn2nix.mkYarnWorkspace {
     src = ./workspace;
   }).package-one;
+  jest = (yarn2nix.mkYarnWorkspace {
+    src = fetchFromGitHub {
+      owner = "facebook";
+      repo = "jest";
+      rev = "v23.4.1";
+      sha256 = "1by94r3mys7jx5ijyk46cz7zxq1al9in78mir612g1qajjfbvmdz";
+    };
+    packageOverrides = {
+      jest = {
+        doInstallCheck = false; # TODO: support root workspace build scripts
+        installCheckPhase = "$out/bin/jest --help";
+      };
+    };
+  }).jest;
 }


### PR DESCRIPTION
It turns out that yarn intentionally supports these!  The jest repository depends on that feature, so I added it as a regression/smoke test target.

Unfortunately as my comment notes, it isn't a proper end-to-end test, so there are failures it would not catch: jest has a single script at the repository's root for transpiling all packages, but I couldn't find a way to leverage that for individual packages.