### PR TITLE
Populate meta automatically

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -293,7 +293,11 @@ in
         workspaceDependencies = workspaceDependenciesTransitive;
       } // (attrs.passthru or {});
 
-      # TODO: populate meta automatically
+      meta = {
+        inherit (nodejs.meta) platforms;
+        description = packageJSON.description or "";
+        homepage = packageJSON.homepage or "";
+      } // (attrs.meta or {});
     });
 
   yarn2nix = mkYarnPackage {

--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,17 @@ in rec {
       non-null = builtins.filter (x: x != null) parts;
     in builtins.concatStringsSep "-" non-null;
 
+  # https://docs.npmjs.com/files/package.json#license
+  # TODO: support expression syntax (OR, AND, etc)
+  spdxLicense = licstr:
+    if licstr == "UNLICENSED" then
+      lib.licenses.unfree
+    else
+      lib.findFirst
+        (l: l ? spdxId && l.spdxId == licstr)
+        { shortName = licstr; }
+        (builtins.attrValues lib.licenses);
+
   # Generates the yarn.nix from the yarn.lock file
   mkYarnNix = yarnLock:
     pkgs.runCommand "yarn.nix" {}
@@ -297,6 +308,8 @@ in
         inherit (nodejs.meta) platforms;
         description = packageJSON.description or "";
         homepage = packageJSON.homepage or "";
+        version = packageJSON.version or "";
+        license = if packageJSON ? license then spdxLicense packageJSON.license else "";
       } // (attrs.meta or {});
     });
 


### PR DESCRIPTION
I'm not sure if you had a different approach in mind, but I thought this would be an improvement.

I would have inherited the platforms attribute from yarn, but surprisingly it doesn't have one.