### PR TITLE
Install most outputs to $out/libexec/$packageName

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -267,10 +267,10 @@ in rec {
       installPhase = attrs.installPhase or ''
         runHook preInstall
 
-        mkdir -p $out/bin
-        mv node_modules $out/node_modules
-        mv deps $out/deps
-        node ${./nix/fixup_bin.js} $out ${lib.concatStringsSep " " publishBinsFor_}
+        mkdir -p $out/{bin,libexec/${pname}}
+        mv node_modules $out/libexec/${pname}/node_modules
+        mv deps $out/libexec/${pname}/deps
+        node ${./nix/fixup_bin.js} $out/bin $out/libexec/${pname}/node_modules ${lib.concatStringsSep " " publishBinsFor_}
 
         runHook postInstall
       '';
@@ -279,7 +279,7 @@ in rec {
       distPhase = ''
         # pack command ignores cwd option
         rm -f .yarnrc
-        cd $out/deps/${pname}
+        cd $out/libexec/${pname}/deps/${pname}
         mkdir -p $out/tarballs/
         yarn pack --ignore-scripts --filename $out/tarballs/${baseName}.tgz
       '';

--- a/nix/fixup_bin.js
+++ b/nix/fixup_bin.js
@@ -2,19 +2,19 @@
 "use strict";
 
 /* Usage:
- * node fixup_bin.js <output_dir> [<bin_pkg_1>, <bin_pkg_2> ... ]
+ * node fixup_bin.js <bin_dir> <modules_dir> [<bin_pkg_1>, <bin_pkg_2> ... ]
  */
 
 const fs = require("fs");
 const path = require("path");
 
-const output = process.argv[2];
-const packages_to_publish_bin = process.argv.slice(3);
-const derivation_bin_path = output + "/bin";
+const derivation_bin_path = process.argv[2];
+const node_modules = process.argv[3];
+const packages_to_publish_bin = process.argv.slice(4);
 
 function processPackage(name) {
   console.log("Processing ", name);
-  const package_path = output + "/deps/" + name;
+  const package_path = node_modules + "/" + name;
   const package_json_path = package_path + "/package.json";
   const package_json = JSON.parse(fs.readFileSync(package_json_path));
   


### PR DESCRIPTION
This seems to be the best practice.  Before this change, any packages with dependencies of the same name and version would conflict.  After it, as far as I can tell, only packages of the same name will conflict.