### PR TITLE
Allow overriding mkYarnPackage distPhase

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -287,7 +287,7 @@ in rec {
       '';
 
       doDist = true;
-      distPhase = ''
+      distPhase = attrs.distPhase or ''
         # pack command ignores cwd option
         rm -f .yarnrc
         cd $out/libexec/${pname}/deps/${pname}


### PR DESCRIPTION
Sometimes it is desirable to override the distPhase (as with my use-case of building an angular-application).