### PR TITLE
Skip local dependencies in generateNix

### DIFF
--- a/bin/yarn2nix.js
+++ b/bin/yarn2nix.js
@@ -39,6 +39,7 @@ function generateNix(lockedDependencies) {
     let dep = lockedDependencies[depRange];
 
     let depRangeParts = depRange.split('@');
+    if (!dep.resolved) continue;
     let [url, sha1] = dep["resolved"].split("#");
     let file_name = path.basename(url)
 


### PR DESCRIPTION
Without this fix node will throw an error when it runs `generateNix` on a local dependency:

```
TypeError: Cannot read property 'split' of undefined
    at generateNix (/nix/store/115k8bis4wsqyrxspx0lyjb60z5ak2vz-yarn2nix-1.0.0/libexec/yarn2nix/deps/yarn2nix/bin/yarn2nix.js:42:39)
    at Promise.all.then (/nix/store/115k8bis4wsqyrxspx0lyjb60z5ak2vz-yarn2nix-1.0.0/libexec/yarn2nix/deps/yarn2nix/bin/yarn2nix.js:142:5)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
    at Function.Module.runMain (module.js:695:11)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:612:3
```