### PR TITLE
Update lockfile dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "yarn2nix": "bin/yarn2nix.js"
   },
   "dependencies": {
-    "@yarnpkg/lockfile": "^1.0.0",
+    "@yarnpkg/lockfile": "^1.1.0",
     "docopt": "^0.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,12 @@
 # yarn lockfile v1
 
 
-"@yarnpkg/lockfile@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.0.0.tgz#33d1dbb659a23b81f87f048762b35a446172add3"
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
 docopt@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/docopt/-/docopt-0.6.2.tgz#b28e9e2220da5ec49f7ea5bb24a47787405eeb11"
+  integrity sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=

--- a/yarn.nix
+++ b/yarn.nix
@@ -3,11 +3,11 @@
   packages = [
 
     {
-      name = "_yarnpkg_lockfile___lockfile_1.0.0.tgz";
+      name = "_yarnpkg_lockfile___lockfile_1.1.0.tgz";
       path = fetchurl {
-        name = "_yarnpkg_lockfile___lockfile_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.0.0.tgz";
-        sha1 = "33d1dbb659a23b81f87f048762b35a446172add3";
+        name = "_yarnpkg_lockfile___lockfile_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz";
+        sha1 = "e77a97fbd345b76d83245edcd17d393b1b41fb31";
       };
     }
 


### PR DESCRIPTION
yarn version 1.10 introduced a new field to the yarn.lock format.  Old versions of this dependency did not preserve that field when serializing, leading to yarn2nix.js erroneously finding changes in, and failing for, _all_ such lockfiles