### PR TITLE
Use deep-equal to check if old and new yarn.locks differ.

### DIFF
--- a/bin/yarn2nix.js
+++ b/bin/yarn2nix.js
@@ -9,6 +9,7 @@ const util = require("util");
 
 const lockfile = require("@yarnpkg/lockfile")
 const docopt = require("docopt").docopt;
+const equal = require("deep-equal");
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -126,9 +127,9 @@ if (json.type != "success") {
 // Check fore missing hashes in the yarn.lock and patch if necessary
 var pkgs = values(json.object);
 Promise.all(pkgs.map(updateResolvedSha1)).then(() => {
-  let newData = lockfile.stringify(json.object);
+  let origJson = lockfile.parse(data)
 
-  if (newData != data) {
+  if (!equal(origJson, json)) {
     console.error("found changes in the lockfile", options["--lockfile"]);
 
     if (options["--no-patch"]) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
+    "deep-equal": "^1.0.1",
     "docopt": "^0.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
+deep-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
+
 docopt@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/docopt/-/docopt-0.6.2.tgz#b28e9e2220da5ec49f7ea5bb24a47787405eeb11"

--- a/yarn.nix
+++ b/yarn.nix
@@ -12,6 +12,15 @@
     }
 
     {
+      name = "deep_equal___deep_equal_1.0.1.tgz";
+      path = fetchurl {
+        name = "deep_equal___deep_equal_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz";
+        sha1 = "f5d260292b660e084eff4cdbc9f08ad3247448b5";
+      };
+    }
+
+    {
       name = "docopt___docopt_0.6.2.tgz";
       path = fetchurl {
         name = "docopt___docopt_0.6.2.tgz";


### PR DESCRIPTION
The previous comparision with stringified data was giving false negatives when keys are in a different order