### PR TITLE
mkYarnWorkspace ignores workspace paths which yarn would ignore

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -167,7 +167,15 @@ in rec {
       else lib.concatMap (child: expandGlobList (base+("/"+child)) rest) matchingChildren;
     # Path -> PathGlob -> [Path]
     expandGlob = base: glob: expandGlobList base (splitGlob glob);
-    packagePaths = lib.concatMap (expandGlob src) packageGlobs;
+    validPackage = path:
+      let
+        packageJSON = path+"/package.json";
+        package = lib.importJSON packageJSON;
+      in
+        builtins.pathExists (path+"/package.json") &&
+        builtins.hasAttr "name" package &&
+        builtins.hasAttr "version" package;
+    packagePaths = builtins.filter validPackage (lib.concatMap (expandGlob src) packageGlobs);
     packages = lib.listToAttrs (map (src:
     let
       packageJSON = src+"/package.json";

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -21,6 +21,14 @@ in
       '';
     };
   }).package-one;
+  inherit (yarn2nix.mkYarnWorkspace {
+    src = fetchFromGitHub {
+      owner = "facebook";
+      repo = "nuclide";
+      rev = "v0.366.0";
+      sha256 = "1iyy8by8p90dncyqi3pgaj36hmz1khi9w1rkhd5gi9nbkkv5can4";
+    };
+  }) nuclide-node-transpiler;
 } // {
   duplicate-pkgs = import ./duplicate-pkgs { inherit yarn2nix; };
   no-import-from-derivation = import ./no-import-from-derivation {

--- a/tests/workspace/package-nameless/package.json
+++ b/tests/workspace/package-nameless/package.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0.0",
+  "license": "MIT"
+}

--- a/tests/workspace/package-versionless/package.json
+++ b/tests/workspace/package-versionless/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "versionless",
+  "license": "MIT"
+}


### PR DESCRIPTION
Directories which match the workspace globs are ignored if:
- they do not have package.json files
- their package.json files don't have a name field
- their package.json files don't have a version field

(Yarn ignores these, either silently or with a warning)