### PR TITLE
Allow passing a source cleaner when building a workspace

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -143,6 +143,7 @@ in rec {
 
   mkYarnWorkspace = {
     src,
+    sourceCleaner ? lib.id,
     packageJSON ? src+"/package.json",
     yarnLock ? src+"/yarn.lock",
     packageOverrides ? {},
@@ -175,8 +176,9 @@ in rec {
       allDependencies = lib.foldl (a: b: a // b) {} (map (field: lib.attrByPath [field] {} package) ["dependencies" "devDependencies"]);
     in rec {
       name = reformatPackageName package.name;
-      value = mkYarnPackage (builtins.removeAttrs attrs ["packageOverrides"] // {
-        inherit src packageJSON yarnLock;
+      value = mkYarnPackage (builtins.removeAttrs attrs ["sourceCleaner" "packageOverrides"] // {
+        inherit packageJSON yarnLock;
+        src = sourceCleaner src;
         workspaceDependencies = lib.mapAttrsToList (name: version: packages.${name})
           (lib.filterAttrs (name: version: packages ? ${name}) allDependencies);
       } // lib.attrByPath [name] {} packageOverrides);


### PR DESCRIPTION
This allows you to pass a `sourceCleaner` when building a workspace:

```nix
mkYarnWorkspace {
  src = ./.;
  sourceCleaner = pkgs.lib.cleanSource;
}
```

This is better than the old approach (`src = pkgs.lib.cleanSource ./.;`) because it is applied per package rather than for the whole workspace at once, so unchanged packages aren't rebuilt just because another package in the workspace was changed.

The default `sourceCleaner` is just a passthrough, so the behaviour should be unchanged if the user doesn't specify one.