### PR TITLE
Don't filter the yarn2nix source

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -366,25 +366,9 @@ in rec {
     });
 
   yarn2nix = mkYarnPackage {
-    src =
-      let
-        src = ./.;
-
-        mkFilter = { dirsToInclude, filesToInclude, root }: path: type:
-          let
-            inherit (pkgs.lib) any flip elem hasSuffix hasPrefix elemAt splitString;
-
-            subpath = elemAt (splitString "${toString root}/" path) 1;
-            spdir = elemAt (splitString "/" subpath) 0;
-          in elem spdir dirsToInclude ||
-            (type == "regular" && elem subpath filesToInclude);
-      in builtins.filterSource
-          (mkFilter {
-            dirsToInclude = ["bin" "lib"];
-            filesToInclude = ["package.json" "yarn.lock"];
-            root = src;
-          })
-          src;
+    # We need to be careful here to ensure that this works in restricted eval mode
+    # when using yarn2ni with IFD. In particular, filtering this source is not allowed.
+    src = ./.;
 
     # yarn2nix is the only package that requires the yarnNix option.
     # All the other projects can auto-generate that file.

--- a/default.nix
+++ b/default.nix
@@ -369,6 +369,8 @@ in rec {
     # We need to be careful here to ensure that this works in restricted eval mode
     # when using yarn2ni with IFD. In particular, filtering this source is not allowed.
     src = ./.;
+    packageJSON = ./package.json;
+    yarnLock = ./yarn.lock;
 
     # yarn2nix is the only package that requires the yarnNix option.
     # All the other projects can auto-generate that file.


### PR DESCRIPTION
Fixes #102 .

This is unfortunate in that we'll pull more stuff into the store and rebuild more often. But the current version doesn't work in restricted eval mode on hydra, and even a trivial use of `builtins.filterSource` causes that.