### PR TITLE
Fix duplication

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -310,8 +310,10 @@ in rec {
         mv $NIX_BUILD_TOP/temp "$PWD/deps/${pname}"
         cd $PWD
 
-        ln -s ${deps}/deps/${pname}/node_modules "deps/${pname}/node_modules"
-
+        if [ -d ${deps}/deps/${pname}/node_modules ]; then
+          cp -r ${deps}/deps/${pname}/node_modules "deps/${pname}/node_modules"
+          chmod -R +w "deps/${pname}/node_modules"
+        fi
         cp -r $node_modules node_modules
         chmod -R +w node_modules
 

--- a/default.nix
+++ b/default.nix
@@ -320,7 +320,6 @@ in rec {
         ${linkDirFunction}
 
         linkDirToDirLinks "$(dirname node_modules/${pname})"
-        ln -s "deps/${pname}" "node_modules/${pname}"
 
         ${workspaceDependencyCopy}
 


### PR DESCRIPTION
This primarily removes the modules as a runtime dependency of the built package. Normally, this isn't an issue, but we're using this to build docker images which we'd prefer to be as small as possible.