### PR TITLE
Set the nodedir so we can build native packages.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -129,6 +129,8 @@ in rec {
 
         ${workspaceDependencyLinks}
 
+        # Set the nodedir so we can build native packages.
+        yarn config --offline set nodedir ${nodejs}
         yarn install ${lib.escapeShellArgs yarnFlags}
 
         ${lib.concatStringsSep "\n" postInstall}


### PR DESCRIPTION
This is necessary for node-gyp to work when building with the sandbox as node headers can't be downloaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moretea/yarn2nix/114)
<!-- Reviewable:end -->
