### PR TITLE
Improve naming regexes

### DIFF
--- a/lib/urlToName.js
+++ b/lib/urlToName.js
@@ -14,8 +14,8 @@ function urlToName(url) {
   }
 
   return url
-    .replace('https://registry.yarnpkg.com/', '') // prevents having long directory names
-    .replace(/[@/:-]/g, '_') // replace @ and : and - characters with underscore
+    .replace(/https:\/\/(.)*(.com)\//g, '') // prevents having long directory names
+    .replace(/[@/%:-]/g, '_') // replace @ and : and - and % characters with underscore
 }
 
 module.exports = urlToName


### PR DESCRIPTION
This PR:

- fixes urlencoded names for packages such as `@babel/core` (which translated to `_babel%2fcore`)
- removes any registry host urls from the name (when using private npm registry)