### PR TITLE
Handle codeload.github.com tarballs

### DIFF
--- a/lib/urlToName.js
+++ b/lib/urlToName.js
@@ -7,9 +7,17 @@ const path = require('path')
 // - https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz
 // - git+https://github.com/srghma/node-shell-quote.git
 // - git+https://1234user:1234pass@git.graphile.com/git/users/1234user/postgraphile-supporter.git
+// - https://codeload.github.com/Gargron/emoji-mart/tar.gz/934f314fd8322276765066e8a2a6be5bac61b1cf
 
 function urlToName(url) {
-  if (url.startsWith('git+')) {
+
+  // Yarn generates `codeload.github.com` tarball URLs, where the final
+  // path component (file name) is the git hash. See #111.
+  // See also https://github.com/yarnpkg/yarn/blob/989a7406/src/resolvers/exotics/github-resolver.js#L24-L26
+  let isCodeloadGitTarballUrl =
+    url.startsWith('https://codeload.github.com/') && url.includes('/tar.gz/')
+
+  if (url.startsWith('git+') || isCodeloadGitTarballUrl) {
     return path.basename(url)
   }
 


### PR DESCRIPTION
Fixes #111.

Fixes `package.json` contents

    "emoji-mart": "Gargron/emoji-mart#build",

being turned into `yaml.lock` by yarn:

    emoji-mart@Gargron/emoji-mart#build:
      version "2.6.3"
      resolved "https://codeload.github.com/Gargron/emoji-mart/tar.gz/934f314fd8322276765066e8a2a6be5bac61b1cf"

and then being turned incorrectly into this by yarn2nix:

    {
      name = "https___codeload.github.com_Gargron_emoji_mart_tar.gz_934f314fd8322276765066e8a2a6be5bac61b1cf";
      path = fetchurl {
        name = "https___codeload.github.com_Gargron_emoji_mart_tar.gz_934f314fd8322276765066e8a2a6be5bac61b1cf";
        url  = "https://codeload.github.com/Gargron/emoji-mart/tar.gz/934f314fd8322276765066e8a2a6be5bac61b1cf";
        sha1 = "1768aa6ab3d6b926f457e082bd4ed7279f6fc9cf";
      };
    }

With this fix, it turns it into

    {
      name = "934f314fd8322276765066e8a2a6be5bac61b1cf";
      path = fetchurl {
        name = "934f314fd8322276765066e8a2a6be5bac61b1cf";
        url  = "https://codeload.github.com/Gargron/emoji-mart/tar.gz/934f314fd8322276765066e8a2a6be5bac61b1cf";
        sha1 = "1768aa6ab3d6b926f457e082bd4ed7279f6fc9cf";
      };
    }

so that the file `934f314fd8322276765066e8a2a6be5bac61b1cf`, which yarn
checks for in the `*-offline` directory, actually exists there.