### PR TITLE
fix path to nix/expectShFunctions.sh in buildPhase of yarn2nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -42,7 +42,7 @@ in rec {
     yarnFlags = defaultYarnFlags ++ ["--production=true"];
 
     buildPhase = ''
-      source ${./expectShFunctions.sh}
+      source ${./nix/expectShFunctions.sh}
 
       expectFilePresent ./node_modules/.yarn-integrity
 


### PR DESCRIPTION
as discussed here: https://github.com/nix-community/yarn2nix/commit/1c903af52712e038ec5930a52693b07b8c1ce669#r40511907